### PR TITLE
PS-733: Fix individualsnamespace bug

### DIFF
--- a/src/main/java/org/plos/namedentity/persist/NamedEntityDBServiceImpl.java
+++ b/src/main/java/org/plos/namedentity/persist/NamedEntityDBServiceImpl.java
@@ -253,7 +253,7 @@ public final class NamedEntityDBServiceImpl implements NamedEntityDBService {
     String cname = clazz.getCanonicalName();
 
     if (cname.equals(IndividualProfile.class.getCanonicalName()))
-      return (List<T>)findIndividualsByNedId(nedId);
+      return (List<T>) findProfilesByNedId(nedId);
     if (cname.equals(Address.class.getCanonicalName()))
       return (List<T>)findAddressesByNedId(nedId);
     if (cname.equals(Email.class.getCanonicalName()))
@@ -436,7 +436,7 @@ public final class NamedEntityDBServiceImpl implements NamedEntityDBService {
   }
 
 
-  private List<IndividualProfile> findIndividualsByNedId(Integer nedId) {
+  private List<IndividualProfile> findProfilesByNedId(Integer nedId) {
     Individualprofiles i   = INDIVIDUALPROFILES.as("i");
     return select(i).where(i.NEDID.equal(nedId)).fetch().into(IndividualProfile.class);
   }

--- a/src/main/java/org/plos/namedentity/rest/BaseResource.java
+++ b/src/main/java/org/plos/namedentity/rest/BaseResource.java
@@ -205,6 +205,11 @@ public abstract class BaseResource {
           new GenericEntity<List<Uniqueidentifier>>(
             namedEntityService.findResolvedEntities(nedId, Uniqueidentifier.class)
           ){}).build();
+      } else if (cname.equals(IndividualProfile.class.getCanonicalName())) {
+        return Response.status(Response.Status.OK).entity(
+            new GenericEntity<List<IndividualProfile>>(
+                namedEntityService.findResolvedEntities(nedId, IndividualProfile.class)
+            ){}).build();
       }
       throw new UnsupportedOperationException("Unsupported child entity: " + child.getSimpleName());
 

--- a/src/main/java/org/plos/namedentity/rest/IndividualsResource.java
+++ b/src/main/java/org/plos/namedentity/rest/IndividualsResource.java
@@ -82,30 +82,47 @@ public class IndividualsResource extends BaseResource {
   }
 
   /* ----------------------------------------------------------------------- */
-  /*  NAME CRUD                                                              */
+  /*  PROFILE CRUD                                                              */
   /* ----------------------------------------------------------------------- */
 
   @POST
-  @Path("/{nedId}/names")
-  @ApiOperation(value = "Add name", response = IndividualComposite.class)
-  public Response addName(@PathParam("nedId") int nedId, IndividualProfile entity) {
+  @Path("/{nedId}/individualprofiles")
+  @ApiOperation(value = "Add profile", response = IndividualProfile.class)
+  public Response addProfile(@PathParam("nedId") int nedId, IndividualProfile entity) {
     return createEntity(nedId, entity);
   }
 
   @POST
-  @Path("/{nedId}/names/{id}")
-  @ApiOperation(value = "Update a name", response = IndividualProfile.class)
-  public Response updateName(@PathParam("nedId") int nedId,
-                         @PathParam("id") int id, IndividualProfile entity) {
+  @Path("/{nedId}/individualprofiles/{profileId}")
+  @ApiOperation(value = "Update a profile", response = IndividualProfile.class)
+  public Response updateProfile(@PathParam("nedId") int nedId,
+                                @PathParam("profileId") int profileId,
+                                IndividualProfile entity) {
 
-    return updateEntity(nedId, id, entity);
+    return updateEntity(nedId, profileId, entity);
   }
 
   @DELETE
-  @Path("/{nedId}/names/{id}")
-  @ApiOperation(value = "Delete a name")
-  public Response deleteName(@PathParam("nedId") int nedId, @PathParam("id") int id) {
-    return deleteEntity(nedId, id, IndividualProfile.class);
+  @Path("/{nedId}/individualprofiles/{profileId}")
+  @ApiOperation(value = "Delete a profile")
+  public Response deleteProfile(@PathParam("nedId") int nedId,
+                                @PathParam("profileId") int profileId) {
+    return deleteEntity(nedId, profileId, IndividualProfile.class);
+  }
+
+  @GET
+  @Path("/{nedId}/individualprofiles/{profileId}")
+  @ApiOperation(value = "Read profile", response = IndividualProfile.class)
+  public Response getProfile(@PathParam("nedId") int nedId,
+                             @PathParam("profileId") int profileId) {
+    return getEntity(nedId, profileId, IndividualProfile.class);
+  }
+
+  @GET
+  @Path("/{nedId}/individualprofiles")
+  @ApiOperation(value = "List profiles", response = IndividualProfile.class)
+  public Response getProfiless(@PathParam("nedId") int nedId) {
+    return getEntities(nedId, IndividualProfile.class);
   }
 
   /* ----------------------------------------------------------------------- */

--- a/src/main/java/org/plos/namedentity/service/NamedEntityServiceImpl.java
+++ b/src/main/java/org/plos/namedentity/service/NamedEntityServiceImpl.java
@@ -41,7 +41,7 @@ public class NamedEntityServiceImpl implements NamedEntityService {
   public <T extends Entity> T resolveValuesToIds(T t) {
 
     if (t instanceof IndividualProfile)
-      resolveIndividual((IndividualProfile) t);
+      resolveProfile((IndividualProfile) t);
     else if (t instanceof Address)
       resolveAddress((Address) t);
     else if (t instanceof Phonenumber)
@@ -62,7 +62,7 @@ public class NamedEntityServiceImpl implements NamedEntityService {
     return t;
   }
 
-  private IndividualProfile resolveIndividual(IndividualProfile entity) {
+  private IndividualProfile resolveProfile(IndividualProfile entity) {
 
     if (entity.getSource() != null)
       entity.setSourcetypeid(nedDBSvc.findTypeValue(nedDBSvc.findTypeClass("Source Applications"), entity.getSource()));

--- a/src/test/java/org/plos/namedentity/rest/NamedEntityResourceTest.java
+++ b/src/test/java/org/plos/namedentity/rest/NamedEntityResourceTest.java
@@ -171,7 +171,7 @@ public class NamedEntityResourceTest extends SpringContextAwareJerseyTest {
         + "\"lastname\":\"" + NEW_LASTNAME + "\""
         + "}";
 
-    Response response = target(INDIVIDUAL_URI + "/1/names/1").request(MediaType.APPLICATION_JSON_TYPE)
+    Response response = target(INDIVIDUAL_URI + "/1/individualprofiles/1").request(MediaType.APPLICATION_JSON_TYPE)
         .post(Entity.json(NEW_INDIVIDUALS_JSON_PAYLOAD));
 
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
@@ -181,7 +181,7 @@ public class NamedEntityResourceTest extends SpringContextAwareJerseyTest {
   @Test
   public void testIndividualDelete() {
     assertEquals(Response.Status.NO_CONTENT.getStatusCode(),
-        target(INDIVIDUAL_URI + "/1/names/1").request().delete().getStatus());
+        target(INDIVIDUAL_URI + "/1/individualprofiles/1").request().delete().getStatus());
   }
 
   @Test

--- a/src/test/java/org/plos/namedentity/service/NamedEntityServiceTest.java
+++ b/src/test/java/org/plos/namedentity/service/NamedEntityServiceTest.java
@@ -316,6 +316,47 @@ public class NamedEntityServiceTest {
   }
 
   @Test
+  public void testProfileEntityCrud() {
+
+    IndividualProfile individualProfile = new IndividualProfile();
+    individualProfile.setFirstname("");
+    individualProfile.setLastname("lastname");
+    individualProfile.setDisplayname("displayname");
+    individualProfile.setNameprefix("Mr.");
+    individualProfile.setNamesuffix("III");
+    individualProfile.setSource("Editorial Manager");
+    individualProfile.setNedid(1);
+
+    try {
+      crudService.create(namedEntityService.resolveValuesToIds(individualProfile));
+      fail();
+    }
+    catch (NedValidationException expected) {
+      System.out.println(expected.getMessage());
+      // first name too short
+    }
+
+    individualProfile.setFirstname("firstname");
+
+    Integer profileId = crudService.create( namedEntityService.resolveValuesToIds(individualProfile) );
+    assertNotNull( profileId );
+
+    IndividualProfile savedEntity = namedEntityService.findResolvedEntityByKey(profileId, IndividualProfile.class);
+    assertNotNull( savedEntity.getFirstname() );
+
+    // UPDATE
+
+    individualProfile.setId(profileId);
+    individualProfile.setFirstname("firstname2");
+
+    assertTrue(crudService.update(namedEntityService.resolveValuesToIds(individualProfile)));
+
+    // DELETE
+
+    assertTrue( crudService.delete(individualProfile) );
+  }
+
+  @Test
   public void testEmailEntityCrud() {
 
     // CREATE email entity. we don't expect the email type to persist.


### PR DESCRIPTION
The /names/ namespace was still being used instead of /individualprofiles/. It was added along with some unit tests.
